### PR TITLE
Build & test C++ SDK on pull_request

### DIFF
--- a/.github/workflows/build_and_test_cpp_sdk.yml
+++ b/.github/workflows/build_and_test_cpp_sdk.yml
@@ -5,6 +5,10 @@ on:
     paths:
     - '.github/workflows/build_and_test_cpp_sdk.yml'
     - 'src/sdk/cpp/**'
+  pull_request:
+    paths:
+    - '.github/workflows/build_and_test_cpp_sdk.yml'
+    - 'src/sdk/cpp/**'
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
Build & test C++ SDK on pull requests. Previously this action was
only triggered on push (which usually happens in a forked repo).