### PR TITLE
Add github action for integration tests

### DIFF
--- a/.github/workflows/run_integration_test.yml
+++ b/.github/workflows/run_integration_test.yml
@@ -1,0 +1,47 @@
+name: Integration test
+
+on: [push, pull_request]
+
+jobs:
+  integration_test:
+    runs-on: ubuntu-latest
+    name: Run integration test
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+
+    - name: Setup & start platform
+      working-directory: ${{github.workspace}}/docker-compose
+      shell: bash
+      # Build & run platform.
+      # It's run daemonized (docker-compose -d) since a running platform
+      # is needed later in the "Run integration tests" step
+      run: docker-compose -f docker-compose.mosquitto.yml -f docker-compose.platform.yml --env-file .env up --build -d
+
+    - name: Setup test dependencies
+      working-directory: ${{github.workspace}}/test/integration-tests
+      shell: bash
+      run: |
+        yarn --frozen-lockfile
+        python3 -m venv .venv
+        source .venv/bin/activate
+        pip install wheel
+        pip install ${{github.workspace}}/src/sdk/python/lib/boschio_iotea-0.4.0-py3-none-any.whl
+
+    - name: Run integration tests
+      working-directory: ${{github.workspace}}/test/integration-tests
+      shell: bash
+      # The required "test talents" are started manually as background
+      # jobs before finally invoking the test runner.
+      run: |
+        source .venv/bin/activate
+        python ./testset_sdk/python/test_set_sdk.py 2>&1 >/dev/null &
+        python ./testset_sdk/python/function_provider.py 2>&1 >/dev/null &
+        node ./testset_sdk/javascript/functionProvider.js 2>&1 >/dev/null &
+        node ./testset_sdk/javascript/testSetSDK.js 2>&1 >/dev/null &
+        node ./runner/javascript/test_runner.js
+      timeout-minutes: 1
+

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![Gitter](https://badges.gitter.im/iot-event-analytics/community.svg)](https://gitter.im/iot-event-analytics/community)
 [![License](https://img.shields.io/badge/License-MPL%202.0-blue.svg)](https://opensource.org/licenses/MPL-2.0)
 [![Unit tests](https://github.com/GENIVI/iot-event-analytics/actions/workflows/test_js_sdk.yml/badge.svg)](https://github.com/GENIVI/iot-event-analytics/actions/workflows/test_js_sdk.yml)
+[![Integration test](https://github.com/GENIVI/iot-event-analytics/actions/workflows/run_integration_test.yml/badge.svg)](https://github.com/GENIVI/iot-event-analytics/actions/workflows/run_integration_test.yml)
 [![C++ SDK](https://github.com/GENIVI/iot-event-analytics/actions/workflows/build_and_test_cpp_sdk.yml/badge.svg)](https://github.com/GENIVI/iot-event-analytics/actions/workflows/build_and_test_cpp_sdk.yml)
 
 (c) Bosch.IO GmbH

--- a/test/integration-tests/runner/javascript/test_runner.js
+++ b/test/integration-tests/runner/javascript/test_runner.js
@@ -16,7 +16,7 @@ process.env.LOG_LEVEL = Logger.ENV_LOG_LEVEL.INFO;
 class TestRunner extends TestRunnerTalent {
     constructor(protocolGatewayConfig) {
         // Define your testSetTalent list and set via super constructor
-        super('testRunner-js', ['testSet-sdk-js', 'testSet-sdk-py', 'testSet-sdk-cpp'], protocolGatewayConfig);
+        super('testRunner-js', ['testSet-sdk-js', 'testSet-sdk-py'], protocolGatewayConfig);
 
         // you can run singular tests say for development also
         //super('testRunner-js', ['testSet-sdk-js'], protocolGatewayConfig);


### PR DESCRIPTION
- Change test runner to programatically wait for the availability of
  dependencies (it was previously necessary to manually ingest
  an event to the platform). Also, exit runner on completion.
- Spin up platform using docker-compose
- Run python & javascript tests for now. C++ talent will follow.
- Test talents are started as background jobs directly in the run
  task for now.

Signed-off-by: John Argérus <fixed-term.john.argerus@se.bosch.com>