### PR TITLE
Improve log render performance by removing jsonata templates

### DIFF
--- a/docker/platform/README.md
+++ b/docker/platform/README.md
@@ -67,6 +67,24 @@ The slim build image does not offer any API (Neither Metadata nor Instance API t
 
 - `docker run --log-opt max-size=1m --log-opt max-file=5 --network="host" -d=true --restart=unless-stopped --name=iotea-platform-<version> -v <some folder>:/app/docker/platform/config iotea-platform-amd64:<version>`
 
+## Performance
+
+### Node.js options
+
+Add the environment variable `NODE_OPTIONS` with all options, you would like to pass to the platform process. For optimize memory usage, set the parameter `--max-old-space-size` to 4/5 of the available memory for this process in MegaBytes.<br>
+Example: `--env NODE_OPTIONS='--max-old-space-size=256' ...`
+
+__Be aware, that starting Node.js with debugger impacts the performance of the platform.__
+
+### Docker options
+
+To reduce the amount of Memory and CPU used, use the flags `--memory=75MB` and `cpus="0.25"`. Be sure that the memory you specify here is calculated via<br>
+
+```javascript
+memory = (`max-old-space-size` * 5) / 4 + 10
+// https://nodejs.org/docs/latest-v12.x/api/cli.html#cli_useful_v8_options
+```
+
 ## Debug
 
 - Start your container, and open a shell `docker run -it <see above> /bin/ash` Use `--rm` option to remove the container after stopping it

--- a/src/core/util/logger.js
+++ b/src/core/util/logger.js
@@ -8,144 +8,131 @@
  * SPDX-License-Identifier: MPL-2.0
  ****************************************************************************/
 
-const jsonata = require('jsonata');
+const uuid = require('uuid');
 
- /**
-  * Logger module.
-  * 
-  * @module logger 
-  */
- 
- /**
-  * The utility Logger class provides methods to log messages under different severity levels. If the log level is set to
-  * WARNING or ERROR, the log messages are sent to stderr, otherwise - to stdout.
-  */
+/**
+ * Logger module.
+ *
+ * @module logger
+ */
+
+/**
+ * The utility Logger class provides methods to log messages under different severity levels. If the log level is set to
+ * WARNING or ERROR, the log messages are sent to stderr, otherwise - to stdout.
+ */
 class Logger {
-     /**
-      * Creates an instance of the Logger class with default log level WARNING.
-      *
-      * @param {string} [name = 'default'] - Descriptive name of the Logger.
-      */
+    /**
+     * Creates an instance of the Logger class with default log level WARNING.
+     *
+     * @param {string} [name = 'default'] - Descriptive name of the Logger.
+     */
     constructor(name = 'default') {
         this.name = name;
         this.logFunction = null;
         this.reset();
     }
 
-     /**
-      * Logs a message with VERBOSE log level. If the message will be actually logged depends on the process environment
-      * variable LOG_LEVEL.
-      *
-      * @param {string} message - Message to be logged.
-      * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
-      * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
-      * data from the context is included in the log message.
-      */
+    /**
+     * Logs a message with VERBOSE log level. If the message will be actually logged depends on the process environment
+     * variable LOG_LEVEL.
+     *
+     * @param {string} message - Message to be logged.
+     * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
+     * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
+     * data from the context is included in the log message.
+     */
     verbose(message, ctx, now) {
         this.__log(message, Logger.__LOG_LEVEL.VERBOSE, ctx, null, now);
     }
 
-     /**
-      * Logs a message with DEBUG log level. If the message will be actually logged depends on the process environment
-      * variable LOG_LEVEL.
-      *
-      * @param {string} message - Message to be logged.
-      * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
-      * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
-      * data from the context is included in the log message.
-      */
+    /**
+     * Logs a message with DEBUG log level. If the message will be actually logged depends on the process environment
+     * variable LOG_LEVEL.
+     *
+     * @param {string} message - Message to be logged.
+     * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
+     * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
+     * data from the context is included in the log message.
+     */
     debug(message, ctx, now) {
         this.__log(message, Logger.__LOG_LEVEL.DEBUG, ctx, null, now);
     }
 
-     /**
-      * Logs a message with INFO log level. If the message will be actually logged depends on the process environment
-      * variable LOG_LEVEL.
-      *
-      * @param {string} message - Message to be logged.
-      * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
-      * {@link module:logger~Logger.createEventContext} and {@link module:logger~ Logger.createContext}. The evaluated
-      * data from the context is included in the log message.
-      */
+    /**
+     * Logs a message with INFO log level. If the message will be actually logged depends on the process environment
+     * variable LOG_LEVEL.
+     *
+     * @param {string} message - Message to be logged.
+     * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
+     * {@link module:logger~Logger.createEventContext} and {@link module:logger~ Logger.createContext}. The evaluated
+     * data from the context is included in the log message.
+     */
     info(message, ctx, now) {
         this.__log(message, Logger.__LOG_LEVEL.INFO, ctx, null, now);
     }
 
-     /**
-      * Logs a message with WARNING log level. If the message will be actually logged depends on the process environment
-      * variable LOG_LEVEL.
-      *
-      * @param {string} message - Message to be logged.
-      * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
-      * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
-      * data from the context is included in the log message.
-      */
+    /**
+     * Logs a message with WARNING log level. If the message will be actually logged depends on the process environment
+     * variable LOG_LEVEL.
+     *
+     * @param {string} message - Message to be logged.
+     * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
+     * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
+     * data from the context is included in the log message.
+     */
     warn(message, ctx, err, now) {
         this.__log(message, Logger.__LOG_LEVEL.WARN, ctx, err, now);
     }
 
-     /**
-      * Logs a message with ERROR log level. If the message will be actually logged depends on the process environment
-      * variable LOG_LEVEL.
-      *
-      * @param {string} message - Message to be logged.
-      * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
-      * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
-      * data from the context is included in the log message.
-      */
+    /**
+     * Logs a message with ERROR log level. If the message will be actually logged depends on the process environment
+     * variable LOG_LEVEL.
+     *
+     * @param {string} message - Message to be logged.
+     * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
+     * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
+     * data from the context is included in the log message.
+     */
     error(message, ctx, err, now) {
         this.__log(message, Logger.__LOG_LEVEL.ERROR, ctx, err, now);
     }
-    
-     /**
-      * Logs a message with ALWAYS log level. If the message will be actually logged depends on the process environment
-      * variable LOG_LEVEL.
-      *
-      * @param {string} message - Message to be logged.
-      * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
-      * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
-      * data from the context is included in the log message.
-      */
+
+    /**
+     * Logs a message with ALWAYS log level. If the message will be actually logged depends on the process environment
+     * variable LOG_LEVEL.
+     *
+     * @param {string} message - Message to be logged.
+     * @param {Object} ctx - Defines the context in which the message is created. See {@link module:logger~Context},
+     * {@link module:logger~Logger.createEventContext} and {@link module:logger~Logger.createContext}. The evaluated
+     * data from the context is included in the log message.
+     */
     always(message, ctx, now) {
         this.__log(message, Logger.__LOG_LEVEL.ALWAYS, ctx, null, now);
     }
 
-     /**
-      * Resets the log level, date format and message format to their default values.
-      */
+    /**
+     * Resets the log level, date format and message format to their default values.
+     */
     reset() {
         this.logFunction = null;
         this.setLogLevel(Logger.__LOG_LEVEL.WARN);
-        // Set ISO 8601 as default
-        this.setDateFormat('[Y0001]-[M01]-[D01]T[H#01]:[m01]:[s01].[f001]Z');
-        this.setMessageFormat('$date & " " & $pad($level, -7, " ") & " [" & $name & "] " & ": " & $message & $context');
+        this.setMessageTemplate('{date} {level} [{name}] : {message}{context}');
     }
 
-     /**
-      * Sets the date format for the log messages.
-      *
-      * @param {string} picture - Format according to jsonata $now definition.
-      */
-    setDateFormat(picture) {
-        // Force UTC
-        //this.dateFormat = jsonata(`$now('${picture}', '+0000')`);
-        this.dateFormat = jsonata(`$fromMillis($now, '${picture}', '+0000')`);
+    /**
+     * Sets the log message template
+     *
+     * @param {string} msgTemplate Can contain placeholders {date}, {level}, {name}, {message}, {context}
+     */
+    setMessageTemplate(msgTemplate) {
+        this.msgTemplate = msgTemplate;
     }
 
-     /**
-      * Sets the format of the log messages.
-      * 
-      * @param {string} jna - Jsonata expression string.
-      */
-    setMessageFormat(jna) {
-        this.messageFormat = jsonata(jna);
-    }
-
-     /**
-      * Sets the log level of this Logger instance.
-      * 
-      * @param {number} numericLevel - A number between 1 (VERBOSE) and 7 (ALWAYS).
-      */
+    /**
+     * Sets the log level of this Logger instance.
+     *
+     * @param {number} numericLevel - A number between 1 (VERBOSE) and 7 (ALWAYS).
+     */
     setLogLevel(numericLevel) {
         if (Object.values(Logger.__LOG_LEVEL).indexOf(numericLevel) === -1) {
             throw new Error(`Given numeric log level ${numericLevel} is invalid`);
@@ -181,13 +168,19 @@ class Logger {
             message += ` [${this.__replaceNewlines(err.stack.replace(/^\s*at\s*(.+)$/gm, '@ $1'))}]`;
         }
 
-        func(this.messageFormat.evaluate('', Object.assign({
+        const replacements = {
             message: this.__replaceNewlines(this.__serializeMessage(message, '<empty message>', '<unserializable message>')),
             name: this.__replaceNewlines(this.__serializeMessage(this.name, '<empty name>', '<unserializable name>')),
-            date: this.dateFormat.evaluate('', { now }),
-            level: this.__formatLogLevel(numericLevel),
+            // Date complies to ISO8601 and therefore is always UTC
+            date: new Date(now).toISOString(),
+            level: this.__formatLogLevel(numericLevel).padStart(7, ' '),
             context: this.__replaceNewlines(this.__serializeMessage(ctx, '<empty context>', '<unserializable context>', ' '))
-        })));
+        };
+
+        func(this.msgTemplate.replace(
+            /{(\w+)}/g,
+            (_, placeholder) => Object.prototype.hasOwnProperty.call(replacements, placeholder) ? replacements[placeholder] : _
+        ));
     }
 
     __serializeMessage(input, emptyInputPlaceholder = '<empty>', nonStringPlaceholder = '<unserializable>', prefix = '') {
@@ -216,26 +209,28 @@ class Logger {
     }
 }
 
- /**
-  * Creates and returns a Context object based on some json data and jsonata
-  * query.
-  *
-  * @param {*} input - JSON object.
-  * @param {string} jna - jsonata query string.
-  * @returns a newly created {@link module:logger~Context} object.
-  */
-Logger.createContext = function createContext(input, jna) {
-    return new Context(input, jna);
+/**
+ * Creates and returns a Context object based on serializable data
+ *
+ * @param {*} input - Serializable object or primitive
+ * @returns a newly created {@link module:logger~Context} object.
+ */
+Logger.createContext = function createContext(input) {
+    return new Context(input);
 };
 
- /**
-  * Creates and returns a Context object based on an event.
-  *
-  * @param {*} ev - JSON event.
-  * @returns a newly created {@link module:logger~Context} object.
-  */
+/**
+ * Creates and returns a Context object based on an event.
+ *
+ * @param {*} ev - IoT Event Analytics event object
+ * @returns a newly created {@link module:logger~Context} object.
+ */
 Logger.createEventContext = function (ev) {
-    return new Context(ev, Logger.EVENT_CTX_JNA);
+    if (ev.cid === undefined) {
+        ev.cid = uuid.v4();
+    }
+
+    return new Context(ev.cid);
 };
 
 Logger.__LOG_LEVEL = {
@@ -248,78 +243,31 @@ Logger.__LOG_LEVEL = {
     ALWAYS: 7
 };
 
- /**
-  * An object containing the string values of the log levels: VERBOSE, DEBUG, INFO, WARN, ERROR, NONE, ALWAYS. Can be
-  * accessed as Logger.ENV_LOG_LEVEL.INFO for example.
-  */
+/**
+ * An object containing the string values of the log levels: VERBOSE, DEBUG, INFO, WARN, ERROR, NONE, ALWAYS. Can be
+ * accessed as Logger.ENV_LOG_LEVEL.INFO for example.
+ */
 Logger.ENV_LOG_LEVEL = Object.keys(Logger.__LOG_LEVEL).reduce((acc, level) => {
     acc[level] = level;
     return acc;
 }, {});
 
- /**
-  * Creates a UUID4-styled random value, if correlation id cid is not available within the event.
-  * Pattern: ########-####-####-####-############.
-  */
-  Logger.EVENT_CTX_JNA = 'cid ? cid : ( $c := "abcdef0123456789"; [[1..8], [1..4], [1..4], [1..4], [1..12]] ~> $map( function($v) { $v ~> $map( function() { $substring($c, $floor($random() * $length($c)), 1) } ) ~> $join() }) ~> $join("-"))';
-
- /**
-  * This class represents a context in which logging is done.
-  */
-  class Context {
+/**
+ * This class represents a context in which logging is done.
+ */
+class Context {
     /**
       * Creates a Context instance.
-      * 
-      * @param {*} input - A json object.
-      * @param {string} jna - A jsonata query string.
-      */      
-    constructor(input, jna) {
-        this.jna = null;
-        this.data = null;
-        this.refresh(input, jna);
+      *
+      * @param {*} input - Serializable object or primitive
+      */
+    constructor(input = null) {
+        this.data = input;
     }
 
     /**
-     * Clears the evaluated jsonata data.
-     */
-    clear() {
-        this.data = null;
-    }
-
-     /**
-      * Applies the jsonata query string on the input json object. Loads the
-      * result into data field.
-      *
-      * @param {*} input - A json object.
-      * @param {string} jna - A jsonata query string.
-      * @returns {@void}
-      */    
-    refresh(input, jna = null) {
-        if (jna !== null) {
-            this.jna = jsonata(jna);
-        }
-
-        if (input === undefined) {
-            this.data = null;
-            return;
-        }
-
-        if (this.jna !== null) {
-            // Transform input according to given jna
-            try {
-                this.data = this.jna.evaluate(input);
-            }
-            catch(err) {
-                this.data = null;
-            }
-        } else {
-            this.data = input;
-        }
-    }
-
-     /**
       * Get a string representation of this Context object.
-      * 
+      *
       * @returns {string}
       */
     toString() {

--- a/test/src/core/util/logger.spec.js
+++ b/test/src/core/util/logger.spec.js
@@ -69,15 +69,6 @@ describe('core.util.jsonModel', () => {
         }
     });
 
-    it('should have the correct date format', () => {
-        logger.reset();
-
-        const now = 1617712424808;
-        const date = logger.dateFormat.evaluate('', { now });
-
-        expect(date).toBe('2021-04-06T12:33:44.808Z');
-    });
-
     it('should have the correct message format', () => {
         const ctx = Logger.createContext('HELLO');
 


### PR DESCRIPTION
Remove testcase, since dateformat could not be set from the outside anymore. We'll stick to ISO8601 format

Signed-off-by: Kiefer Lars-Erich <Lars-Erich.Kiefer@de.bosch.com>