### PR TITLE
Make C++ logs look more JS/Python logs

### DIFF
--- a/src/sdk/cpp/examples/basic/basic.cpp
+++ b/src/sdk/cpp/examples/basic/basic.cpp
@@ -29,8 +29,6 @@ using iotea::core::ErrorMessage;
 using iotea::core::Event;
 using iotea::core::schema::rule_ptr;
 
-namespace logging = iotea::core::log;
-
 constexpr char SERVER_ADDRESS[] = "tcp://localhost:1883";
 
 class MyService : public Talent {
@@ -42,11 +40,11 @@ class MyService : public Talent {
     }
 
     void OnEvent(const Event& event, event_ctx_ptr) override {
-        logging::Info() << "Event: " << event.GetValue().dump(4);
+        GetLogger().Info() << "Event: " << event.GetValue().dump(4);
     }
 
     void OnError(const ErrorMessage& msg) override {
-        logging::Error() << "Something went a awry, " << msg.GetMessage(); 
+        GetLogger().Error() << "Something went a awry, " << msg.GetMessage(); 
     };
 };
 

--- a/src/sdk/cpp/examples/callback_mode/callback_mode.cpp
+++ b/src/sdk/cpp/examples/callback_mode/callback_mode.cpp
@@ -27,8 +27,7 @@ using iotea::core::LessThan;
 using iotea::core::ErrorMessage;
 using iotea::core::Event;
 using iotea::core::schema::rule_ptr;
-
-namespace logging = iotea::core::log;
+using iotea::core::logging::NamedLogger;
 
 constexpr char SERVER_ADDRESS[] = "tcp://localhost:1883";
 
@@ -38,10 +37,14 @@ void signal_handler(int) {
     client.Stop();
 }
 
+static auto logger = NamedLogger{"CallbackMode"};
+
 int main(int, char**) {
+    logger.Error() << "Fired up";
+
     // Register a global error handler
     client.OnError = [](const ErrorMessage& msg) {
-        logging::Error() << "Something went a awry, " << msg.GetMessage(); 
+        logger.Error() << "Something went a awry, " << msg.GetMessage();
     };
 
 
@@ -68,7 +71,7 @@ int main(int, char**) {
 
     // Create a stand-alone subscription and bind matching events to a function
     client.Subscribe(IsSet("temp", "kuehlschrank"), [](const Event&, event_ctx_ptr) {
-        logging::Info() << "The temp is set!";
+        logger.Info() << "The temp is set!";
     });
 
 
@@ -81,10 +84,10 @@ int main(int, char**) {
         auto token = ctx->Call(multiply, json{value, value}, 1000);
 
         auto reply_handler = [](const std::vector<json>& reply) {
-            logging::Info() << "kuelschrank.temp=" << reply[0].get<int>(); 
+            logger.Info() << "kuelschrank.temp=" << reply[0].get<int>(); 
         };
         auto timeout_handler = []{
-            logging::Info() << "timed out waiting for result";
+            logger.Info() << "timed out waiting for result";
         };
 
         // Defer handling of the function reply until some later point in time.

--- a/src/sdk/cpp/examples/echo/echo_consumer.cpp
+++ b/src/sdk/cpp/examples/echo/echo_consumer.cpp
@@ -14,7 +14,6 @@
 
 #include "nlohmann/json.hpp"
 #include "client.hpp"
-#include "logging.hpp"
 #include "mqtt_client.hpp"
 
 using namespace iotea::core;
@@ -54,17 +53,17 @@ class EchoConsumer : public Talent {
     void OnEvent(const Event& event, event_ctx_ptr context) override {
         if (event.GetType() == PROVIDED_FETAURE_TYPE) {
             auto message = event.GetValue().get<std::string>();
-            log::Info() << "Received message:  '" << message << "'";
+            GetLogger().Info() << "Received message:  '" << message << "'";
 
             auto t = context->Call(echo_provider.echo, message);
 
-            context->Gather([](std::vector<json> replies) {
-                    log::Info() << "Received echo:     '" << replies[0].dump(4) << "'";
+            context->Gather([this](std::vector<json> replies) {
+                    GetLogger().Info() << "Received echo:     '" << replies[0].dump(4) << "'";
                 }, nullptr, t);
 
-            log::Info() << "Forwarded message: '" << message << "'";
+            GetLogger().Info() << "Forwarded message: '" << message << "'";
         } else {
-            log::Warn() << "UNKNOWN EVENT RECEIVED";
+            GetLogger().Warn() << "UNKNOWN EVENT RECEIVED";
         }
     }
 };

--- a/src/sdk/cpp/examples/echo/echo_observer.cpp
+++ b/src/sdk/cpp/examples/echo/echo_observer.cpp
@@ -14,7 +14,6 @@
 
 #include "nlohmann/json.hpp"
 #include "client.hpp"
-#include "logging.hpp"
 #include "mqtt_client.hpp"
 #include "schema.hpp"
 
@@ -41,12 +40,12 @@ class EchoObserver : public Talent {
     void OnEvent(const Event& event, event_ctx_ptr) override {
         if (event.GetFeature() == SUBSCRIBED_ECHO_EVENT) {
             auto message = event.GetValue().get<std::string>();
-            log::Info() << "Received echo: '" << message << "'";
+            GetLogger().Info() << "Received echo: '" << message << "'";
         } else if (event.GetFeature() == SUBSCRIBED_COUNT_EVENT) {
             auto echoCount = event.GetValue().get<unsigned int>();
-            log::Info() << "Received echoCount: " << echoCount;
+            GetLogger().Info() << "Received echoCount: " << echoCount;
         } else {
-            log::Warn() << "UNKNOWN EVENT RECEIVED";
+            GetLogger().Warn() << "UNKNOWN EVENT RECEIVED";
         }
     }
 };

--- a/src/sdk/cpp/examples/echo/echo_provider.cpp
+++ b/src/sdk/cpp/examples/echo/echo_provider.cpp
@@ -60,7 +60,7 @@ public:
 
         std::transform(message.begin(), message.end(), message.begin(), ::toupper);
         context->Reply(message);
-        GetLogger().Info() << "Replying echo:      " << message;
+        GetLogger().Info() << "Replying echo: " << message;
 
         auto notifyContext = NewEventContext(NOTIFICATION_CONTEXT);
         notifyContext->Emit(TALENT_NAME+"."+EVENT_ECHO_COUNT, echoCount_);

--- a/src/sdk/cpp/examples/echo/echo_provider.cpp
+++ b/src/sdk/cpp/examples/echo/echo_provider.cpp
@@ -14,7 +14,6 @@
 
 #include "nlohmann/json.hpp"
 #include "client.hpp"
-#include "logging.hpp"
 #include "mqtt_client.hpp"
 
 using namespace iotea::core;
@@ -54,14 +53,14 @@ public:
     schema::rule_ptr OnGetRules() const override { return nullptr; }
 
     void Echo(const json& args, call_ctx_ptr context) {
-        log::Info() << "Raw args: " << args.dump(4);
+        GetLogger().Info() << "Raw args: " << args.dump(4);
         auto message = args[0].get<std::string>();
-        log::Info() << "Received echo call: " << message;
+        GetLogger().Info() << "Received echo call: " << message;
         ++echoCount_;
 
         std::transform(message.begin(), message.end(), message.begin(), ::toupper);
         context->Reply(message);
-        log::Info() << "Replying echo:      " << message;
+        GetLogger().Info() << "Replying echo:      " << message;
 
         auto notifyContext = NewEventContext(NOTIFICATION_CONTEXT);
         notifyContext->Emit(TALENT_NAME+"."+EVENT_ECHO_COUNT, echoCount_);
@@ -69,14 +68,14 @@ public:
     }
 
     void GetEchoCount(call_ctx_ptr context) {
-        log::Info() << "Received GetEchoCount call";
+        GetLogger().Info() << "Received GetEchoCount call";
         context->Reply(echoCount_);
-        log::Info() << "Replying echoCount: " << echoCount_;
+        GetLogger().Info() << "Replying echoCount: " << echoCount_;
     }
 
     void SetEchoCount(const json& args, call_ctx_ptr context) {
         auto newEchoCount = args[0].get<unsigned int>();
-        log::Info() << "Received setEchoCount call: " << newEchoCount;
+        GetLogger().Info() << "Received setEchoCount call: " << newEchoCount;
         if (newEchoCount != echoCount_) {
             echoCount_ = newEchoCount;
             auto notifyContext = NewEventContext(NOTIFICATION_CONTEXT);

--- a/src/sdk/cpp/examples/functions/functions.cpp
+++ b/src/sdk/cpp/examples/functions/functions.cpp
@@ -13,7 +13,6 @@
 
 #include "nlohmann/json.hpp"
 #include "client.hpp"
-#include "logging.hpp"
 #include "mqtt_client.hpp"
 
 
@@ -26,8 +25,6 @@ using iotea::core::IsSet;
 using iotea::core::event_ctx_ptr;
 using iotea::core::call_ctx_ptr;
 using iotea::core::schema::rule_ptr;
-
-namespace logging = iotea::core::log;
 
 constexpr char SERVER_ADDRESS[] = "tcp://localhost:1883";
 
@@ -106,18 +103,18 @@ class MathFunctions : public FunctionTalent {
         auto v = event.GetValue();
 
         auto tsum = ctx->Call(sum, v);
-        ctx->Gather([v](const std::vector<json>& replies) {
-                logging::Info() << "sum(" << v << ") = " << replies[0].get<int>();
+        ctx->Gather([this, v](const std::vector<json>& replies) {
+                GetLogger().Info() << "sum(" << v << ") = " << replies[0].get<int>();
         }, nullptr, tsum);
 
         auto tfac = ctx->Call(fac, v);
-        ctx->Gather([v](const std::vector<json>& replies) {
-                logging::Info() << "fac(" << v << ") = " << replies[0].get<int>();
+        ctx->Gather([this, v](const std::vector<json>& replies) {
+                GetLogger().Info() << "fac(" << v << ") = " << replies[0].get<int>();
         }, nullptr, tfac);
 
         auto tfib = ctx->Call(fib, v);
-        ctx->Gather([v](const std::vector<json>& replies) {
-                logging::Info() << "fib(" << v << ") = " << replies[0].get<int>();
+        ctx->Gather([this, v](const std::vector<json>& replies) {
+                GetLogger().Info() << "fib(" << v << ") = " << replies[0].get<int>();
         }, nullptr, tfib);
     }
 

--- a/src/sdk/cpp/examples/subclass_mode/subclass_mode.cpp
+++ b/src/sdk/cpp/examples/subclass_mode/subclass_mode.cpp
@@ -29,8 +29,6 @@ using iotea::core::event_ctx_ptr;
 using iotea::core::call_ctx_ptr;
 using iotea::core::schema::rule_ptr;
 
-namespace logging = iotea::core::log;
-
 constexpr char SERVER_ADDRESS[] = "tcp://localhost:1883";
 
 class MyService : public FunctionTalent {
@@ -45,7 +43,7 @@ class MyService : public FunctionTalent {
     }
 
     void OnError(const ErrorMessage& msg) override {
-        logging::Error() << "Something went a awry, " << msg.GetMessage(); 
+        GetLogger().Error() << "Something went a awry, " << msg.GetMessage(); 
     };
 };
 
@@ -54,7 +52,7 @@ class MyReporingTalent : public Talent {
      MyReporingTalent() : Talent("my_reporting_talent") { }
 
      void OnEvent(const Event&, event_ctx_ptr) override {
-        logging::Info() << "The temp is set!";
+        GetLogger().Info() << "The temp is set!";
      }
 
      rule_ptr OnGetRules() const override {
@@ -62,7 +60,7 @@ class MyReporingTalent : public Talent {
      }
 
     void OnError(const ErrorMessage& msg) override {
-        logging::Error() << "Something went a awry, " << msg.GetMessage(); 
+        GetLogger().Error() << "Something went a awry, " << msg.GetMessage(); 
     };
 };
 
@@ -76,16 +74,16 @@ class MyCallingTalent : public Talent {
      }
 
      void OnEvent(const Event& e, event_ctx_ptr ctx) override {
-        logging::Info() << "EventReceived in MyCallingTalent";
+        GetLogger().Info() << "EventReceived in MyCallingTalent";
         auto value = e.GetValue();
 
         auto token = ctx->Call(multiply, json{value, value}, 1000);
 
-        auto reply_handler = [](const std::vector<json>& reply) {
-            logging::Info() << "kuelschrank.temp=" << reply[0].get<int>(); 
+        auto reply_handler = [this](const std::vector<json>& reply) {
+            GetLogger().Info() << "kuelschrank.temp=" << reply[0].get<int>(); 
         };
-        auto timeout_handler = []{
-            logging::Info() << "timed out waiting for result";
+        auto timeout_handler = [this]{
+            GetLogger().Info() << "timed out waiting for result";
         };
 
         ctx->Gather(reply_handler, timeout_handler, token);
@@ -96,7 +94,7 @@ class MyCallingTalent : public Talent {
      }
 
     void OnError(const ErrorMessage& msg) override {
-        logging::Error() << "Something went a awry, " << msg.GetMessage(); 
+        GetLogger().Error() << "Something went a awry, " << msg.GetMessage(); 
     };
 };
 

--- a/src/sdk/cpp/lib/include/mqtt_client.hpp
+++ b/src/sdk/cpp/lib/include/mqtt_client.hpp
@@ -27,7 +27,6 @@
 
 
 #include "interface.hpp"
-#include "logging.hpp"
 
 namespace iotea {
 namespace core {
@@ -73,7 +72,6 @@ class MqttClient : public Publisher {
 
     std::vector<std::pair<std::string, int>> topics_;
 
-   private:
     void ChangeState(State state);
 };
 

--- a/src/sdk/cpp/lib/include/talent.hpp
+++ b/src/sdk/cpp/lib/include/talent.hpp
@@ -18,6 +18,9 @@
 #include "call.hpp"
 #include "context.hpp"
 
+using iotea::core::logging::Logger;
+using iotea::core::logging::NamedLogger;
+
 namespace iotea {
 namespace core {
 
@@ -269,6 +272,13 @@ class Talent {
      */
     std::string GetOutputName(const std::string& type, const std::string& talent_id, const std::string& feature) const;
 
+    /**
+     * @brief Get the logger associated with this Talent.
+     *
+     * @return NamedLogger
+     */
+    NamedLogger GetLogger() const;
+
    protected:
     std::vector<Callee> callees_;
     schema::Talent schema_;
@@ -302,6 +312,7 @@ class Talent {
    private:
     const std::string talent_id_;
     std::string channel_id_;
+    NamedLogger logger_;
 
     on_event_func_ptr on_event_;
     context_generator_func_ptr context_gen_;

--- a/src/sdk/cpp/lib/src/client.cpp
+++ b/src/sdk/cpp/lib/src/client.cpp
@@ -63,7 +63,7 @@ void CalleeTalent::AddCallees(const std::vector<Callee>& callees) {
 //
 // Client
 //
-static auto client_logger = NamedLogger("Client");
+static auto logger = NamedLogger("Client");
 
 Client::Client(const std::string& connection_string)
     : mqtt_client_{new MqttClient(connection_string, GenerateUUID())}
@@ -152,7 +152,7 @@ void Client::Subscribe(schema::rule_ptr rules, const OnEvent callback) {
 }
 
 void Client::HandleDiscover(const std::string& msg) {
-    client_logger.Debug() << "Received discovery message.";
+    logger.Debug() << "Received discovery message.";
     auto payload = json::parse(msg);
     auto dmsg = DiscoverMessage::FromJson(payload);
     auto return_topic = mqtt_topic_ns_ + "/" + dmsg.GetReturnTopic();
@@ -182,7 +182,7 @@ void Client::HandleDiscover(const std::string& msg) {
 }
 
 void Client::HandlePlatformEvent(const std::string& msg) {
-    client_logger.Debug() << "Received platform message.";
+    logger.Debug() << "Received platform message.";
     auto payload = json::parse(msg);
     auto event = PlatformEvent::FromJson(payload);
 
@@ -241,30 +241,30 @@ void Client::HandleEvent(const std::string& talent_id, const std::string& raw) {
     Event event;
 
     try {
-        client_logger.Debug() << "Parse payload.";
+        logger.Debug() << "Parse payload.";
         auto payload = json::parse(raw);
 
         // First check if this is an error message
         auto msg = Message::FromJson(payload);
         if (msg.IsError()) {
-            client_logger.Debug() << "Create error message from payload.";
+            logger.Debug() << "Create error message from payload.";
             auto err = ErrorMessage::FromJson(payload);
 
             HandleError(err);
             return;
         }
 
-        client_logger.Debug() << "Create event from payload.";
+        logger.Debug() << "Create event from payload.";
         event = Event::FromJson(payload);
     } catch (const json::parse_error& e) {
-        client_logger.Error() << "Failed to parse event message.";
+        logger.Error() << "Failed to parse event message.";
         return;
     } catch (const json::type_error& e) {
-        client_logger.Error() << "Unexpected content in event message: " << e.what();
+        logger.Error() << "Unexpected content in event message: " << e.what();
         return;
     }
 
-    client_logger.Debug() << "HandleEvent, talent_id=" << talent_id << ", feature=" << event.GetFeature();
+    logger.Debug() << "HandleEvent, talent_id=" << talent_id << ", feature=" << event.GetFeature();
 
     // Is it a function talent?
     auto ft_iter = std::find_if(function_talents_.begin(), function_talents_.end(), [talent_id](const auto& item) {
@@ -319,12 +319,12 @@ void Client::HandleEvent(const std::string& talent_id, const std::string& raw) {
         return;
     }
 
-    client_logger.Info() << "Received event for unregistered talent";
+    logger.Info() << "Received event for unregistered talent";
 }
 
 void Client::HandleCallReply(const std::string& talent_id, const std::string&
         channel_id, const call_id_t& call_id, const std::string& msg) {
-    client_logger.Debug() << "Received reply, talent_id: " << talent_id << ", channel_id=" << channel_id << " call_id=" << call_id;
+    logger.Debug() << "Received reply, talent_id: " << talent_id << ", channel_id=" << channel_id << " call_id=" << call_id;
 
     auto payload = json::parse(msg);
     auto event = Event::FromJson(payload);
@@ -332,7 +332,7 @@ void Client::HandleCallReply(const std::string& talent_id, const std::string&
 
     auto gatherer = reply_handler_->ExtractGatherer(call_id);
     if (!gatherer) {
-        client_logger.Debug() << "Could not find gatherer of call id " << call_id;
+        logger.Debug() << "Could not find gatherer of call id " << call_id;
         return;
     }
 
@@ -361,9 +361,9 @@ std::string Client::GetPlatformEventsTopic() const {
 }
 
 void Client::Receive(const std::string& topic, const std::string& msg) {
-    client_logger.Debug() << "Message arrived.";
-    client_logger.Debug() << "\ttopic: '" << topic << "'";
-    client_logger.Debug() << "\tpayload: '" << msg;
+    logger.Debug() << "Message arrived.";
+    logger.Debug() << "\ttopic: '" << topic << "'";
+    logger.Debug() << "\tpayload: '" << msg;
 
     std::cmatch m;
 
@@ -404,7 +404,7 @@ void Client::Receive(const std::string& topic, const std::string& msg) {
         return;
     }
 
-    client_logger.Error() << "Unexpected topic: << " << topic;
+    logger.Error() << "Unexpected topic: << " << topic;
 }
 
 void Client::UpdateTime(int64_t ts) {

--- a/src/sdk/cpp/lib/src/client.cpp
+++ b/src/sdk/cpp/lib/src/client.cpp
@@ -12,6 +12,7 @@
 
 #include "event.hpp"
 #include "client.hpp"
+#include "logging.hpp"
 
 namespace iotea {
 namespace core {
@@ -62,6 +63,8 @@ void CalleeTalent::AddCallees(const std::vector<Callee>& callees) {
 //
 // Client
 //
+static auto client_logger = NamedLogger("Client");
+
 Client::Client(const std::string& connection_string)
     : mqtt_client_{new MqttClient(connection_string, GenerateUUID())}
     , callee_talent_(new CalleeTalent{GenerateUUID()})
@@ -149,7 +152,7 @@ void Client::Subscribe(schema::rule_ptr rules, const OnEvent callback) {
 }
 
 void Client::HandleDiscover(const std::string& msg) {
-    log::Debug() << "Received discovery message.";
+    client_logger.Debug() << "Received discovery message.";
     auto payload = json::parse(msg);
     auto dmsg = DiscoverMessage::FromJson(payload);
     auto return_topic = mqtt_topic_ns_ + "/" + dmsg.GetReturnTopic();
@@ -179,7 +182,7 @@ void Client::HandleDiscover(const std::string& msg) {
 }
 
 void Client::HandlePlatformEvent(const std::string& msg) {
-    log::Debug() << "Received platform message.";
+    client_logger.Debug() << "Received platform message.";
     auto payload = json::parse(msg);
     auto event = PlatformEvent::FromJson(payload);
 
@@ -238,30 +241,30 @@ void Client::HandleEvent(const std::string& talent_id, const std::string& raw) {
     Event event;
 
     try {
-        log::Debug() << "Parse payload.";
+        client_logger.Debug() << "Parse payload.";
         auto payload = json::parse(raw);
 
         // First check if this is an error message
         auto msg = Message::FromJson(payload);
         if (msg.IsError()) {
-            log::Debug() << "Create error message from payload.";
+            client_logger.Debug() << "Create error message from payload.";
             auto err = ErrorMessage::FromJson(payload);
 
             HandleError(err);
             return;
         }
 
-        log::Debug() << "Create event from payload.";
+        client_logger.Debug() << "Create event from payload.";
         event = Event::FromJson(payload);
     } catch (const json::parse_error& e) {
-        log::Error() << "Failed to parse event message.";
+        client_logger.Error() << "Failed to parse event message.";
         return;
     } catch (const json::type_error& e) {
-        log::Error() << "Unexpected content in event message: " << e.what();
+        client_logger.Error() << "Unexpected content in event message: " << e.what();
         return;
     }
 
-    log::Debug() << "HandleEvent, talent_id=" << talent_id << ", feature=" << event.GetFeature();
+    client_logger.Debug() << "HandleEvent, talent_id=" << talent_id << ", feature=" << event.GetFeature();
 
     // Is it a function talent?
     auto ft_iter = std::find_if(function_talents_.begin(), function_talents_.end(), [talent_id](const auto& item) {
@@ -316,12 +319,12 @@ void Client::HandleEvent(const std::string& talent_id, const std::string& raw) {
         return;
     }
 
-    log::Info() << "Received event for unregistered talent";
+    client_logger.Info() << "Received event for unregistered talent";
 }
 
 void Client::HandleCallReply(const std::string& talent_id, const std::string&
         channel_id, const call_id_t& call_id, const std::string& msg) {
-    log::Debug() << "Received reply, talent_id: " << talent_id << ", channel_id=" << channel_id << " call_id=" << call_id;
+    client_logger.Debug() << "Received reply, talent_id: " << talent_id << ", channel_id=" << channel_id << " call_id=" << call_id;
 
     auto payload = json::parse(msg);
     auto event = Event::FromJson(payload);
@@ -329,7 +332,7 @@ void Client::HandleCallReply(const std::string& talent_id, const std::string&
 
     auto gatherer = reply_handler_->ExtractGatherer(call_id);
     if (!gatherer) {
-        log::Debug() << "Could not find gatherer of call id " << call_id;
+        client_logger.Debug() << "Could not find gatherer of call id " << call_id;
         return;
     }
 
@@ -358,9 +361,9 @@ std::string Client::GetPlatformEventsTopic() const {
 }
 
 void Client::Receive(const std::string& topic, const std::string& msg) {
-    log::Debug() << "Message arrived.";
-    log::Debug() << "\ttopic: '" << topic << "'";
-    log::Debug() << "\tpayload: '" << msg;
+    client_logger.Debug() << "Message arrived.";
+    client_logger.Debug() << "\ttopic: '" << topic << "'";
+    client_logger.Debug() << "\tpayload: '" << msg;
 
     std::cmatch m;
 
@@ -401,7 +404,7 @@ void Client::Receive(const std::string& topic, const std::string& msg) {
         return;
     }
 
-    log::Error() << "Unexpected topic: << " << topic;
+    client_logger.Error() << "Unexpected topic: << " << topic;
 }
 
 void Client::UpdateTime(int64_t ts) {

--- a/src/sdk/cpp/lib/src/event.cpp
+++ b/src/sdk/cpp/lib/src/event.cpp
@@ -16,12 +16,16 @@
 #include <vector>
 #include <algorithm>
 
+#include "logging.hpp"
 #include "schema.hpp"
 #include "util.hpp"
+
+using iotea::core::logging::NamedLogger;
 
 namespace iotea {
 namespace core {
 
+static auto logger = NamedLogger{"Message"};
 
 // Message
 //
@@ -70,7 +74,7 @@ DiscoverMessage DiscoverMessage::FromJson(const json& j) {
         version = j["version"].get<std::string>();
     } else {
         version = "0.0.0";
-        log::Warn() << "Discover Message API doesn't fit the sdk version. Please update to avoid unknown behavior.";
+        logger.Warn() << "Discover Message API doesn't fit the sdk version. Please update to avoid unknown behavior.";
     }
 
     auto return_topic = j["returnTopic"].get<std::string>();

--- a/src/sdk/cpp/lib/src/jsonquery.cpp
+++ b/src/sdk/cpp/lib/src/jsonquery.cpp
@@ -17,7 +17,6 @@
 #include "nlohmann/json.hpp"
 
 #include "jsonquery.hpp"
-#include "logging.hpp"
 
 using json = nlohmann::json;
 

--- a/src/sdk/cpp/lib/src/logging.cpp
+++ b/src/sdk/cpp/lib/src/logging.cpp
@@ -10,16 +10,18 @@
 
 #include "logging.hpp"
 
-#include <ctime>
+#include <chrono>
 #include <iostream>
+#include <iomanip>
 #include <mutex>
+#include <sstream>
 #include <string>
 
 #include "util.hpp"
 
 namespace iotea {
 namespace core {
-namespace log {
+namespace logging {
 
 Level GetLogLevel() {
     static const char* log_level_env = "IOTEA_LOG_LEVEL";
@@ -50,47 +52,46 @@ Level GetLogLevel() {
 }
 
 //
-// Logger
+// InternalLogger
 //
-Logger::Logger()
+InternalLogger::InternalLogger()
     : os_{std::cout.rdbuf()} {}
 
-Logger* Logger::Get() {
-    static Logger logger;
+InternalLogger* InternalLogger::Get() {
+    static InternalLogger logger;
     return &logger;
 }
 
-Level Logger::GetLevel() const { return level_; }
+Level InternalLogger::GetLevel() const { return level_; }
 
-void Logger::SetLevel(const Level level) { level_ = level; }
+void InternalLogger::SetLevel(const Level level) { level_ = level; }
 
-std::ostream& Logger::GetStream() { return os_; }
+std::ostream& InternalLogger::GetStream() { return os_; }
 
 //
-// LoggerFriend
+// Logger
 //
-
-LoggerFriend::LoggerFriend(Logger* logger, const Level level, int call_depth)
+Logger::Logger(InternalLogger* logger, const Level level, int call_depth)
     : logger_{logger}
     , level_{level}
     , call_depth_{call_depth} {
     logger->mutex_.lock();
 }
 
-LoggerFriend::LoggerFriend(Logger* logger)
-    : LoggerFriend{logger, Level::INFO, 0} {}
+Logger::Logger(InternalLogger* logger)
+    : Logger{logger, Level::INFO, 0} {}
 
-LoggerFriend::LoggerFriend(const LoggerFriend& other)
-    : LoggerFriend{other.logger_, other.level_, other.call_depth_ + 1} {}
+Logger::Logger(const Logger& other)
+    : Logger{other.logger_, other.level_, other.call_depth_ + 1} {}
 
-LoggerFriend::~LoggerFriend() {
+Logger::~Logger() {
     if (call_depth_ == 0) {
         *this << '\n';
     }
     logger_->mutex_.unlock();
 }
 
-LoggerFriend& LoggerFriend::operator<<(const std::ostream& (*f)(std::ostream&)) {
+Logger& Logger::operator<<(const std::ostream& (*f)(std::ostream&)) {
     if (logger_->GetLevel() <= level_) {
         logger_->GetStream() << f;
     }
@@ -102,49 +103,67 @@ LoggerFriend& LoggerFriend::operator<<(const std::ostream& (*f)(std::ostream&)) 
 // Friend functions
 //
 void SetLevel(const Level level) {
-    LoggerFriend p{Logger::Get()};
+    Logger p{InternalLogger::Get()};
     p.logger_->SetLevel(level);
 }
 
-LoggerFriend Log(const Level level) {
-    LoggerFriend p{Logger::Get(), level};
-
-    std::time_t now = ::time(nullptr);
-
-    struct tm t;
-    ::localtime_r(&now, &t);
-
-    char tbuf[26];
-
-    // %a: The abbreviated name of the day of the week according to the current locale.
-    // %b: The abbreviated month name according to the current locale.
-    // %d: The day of the month as a decimal number (range 01 to 31).
-    // %H: The hour as a decimal number using a 24-hour clock (range 00 to 23).
-    // %M: The minute as a decimal number (range 00 to 59).
-    // %S: The second as a decimal number (range 00 to 60).
-    // %Y; The year as a decimal number including the century.
-    strftime(tbuf, sizeof(tbuf)/sizeof(tbuf[0]), "%a %b %d %H:%M:%S %Y", &t);
+Logger Log(const Level level) {
+    auto now = std::chrono::system_clock::now();
+    auto ts = std::chrono::system_clock::to_time_t(now);
+    Logger p{InternalLogger::Get(), level};
 
     static const char* tags[]{
-        " [DEBUG] ",
-        " [ INFO] ",
-        " [ WARN] ",
-        " [ERROR] ",
+        " DEBUG ",
+        "  INFO ",
+        "  WARN ",
+        " ERROR ",
     };
 
-    p << tbuf << tags[static_cast<int>(level)];
+    std::ostringstream ss;
+    ss << std::put_time(gmtime(&ts), "%FT%TZ");
+    p <<  ss.str() << tags[static_cast<int>(level)];
 
     return p;
 }
 
-LoggerFriend Debug() { return Log(Level::DEBUG); }
+Logger Debug() { return Log(Level::DEBUG); }
 
-LoggerFriend Info() { return Log(Level::INFO); }
+Logger Info() { return Log(Level::INFO); }
 
-LoggerFriend Warn() { return Log(Level::WARNING); }
+Logger Warn() { return Log(Level::WARNING); }
 
-LoggerFriend Error() { return Log(Level::ERROR); }
+Logger Error() { return Log(Level::ERROR); }
 
-}  // namespace log
+//
+// NamedLogger
+//
+NamedLogger::NamedLogger(const std::string& name)
+    : name_{name} {}
+
+Logger NamedLogger::Debug() const {
+    auto l = logging::Debug();
+    l << name_ << " : ";
+    return l;
+}
+
+Logger NamedLogger::Info() const {
+    auto l = logging::Info();
+    l << name_ << " : ";
+    return l;
+}
+
+Logger NamedLogger::Warn() const {
+    auto l = logging::Warn();
+    l << name_ << " : ";
+    return l;
+}
+
+Logger NamedLogger::Error() const {
+    auto l = logging::Error();
+    l << name_ << " : ";
+    return l;
+}
+
+}  // namespace logging
 }  // namespace core
 }  // namespace iotea

--- a/src/sdk/cpp/lib/src/logging.cpp
+++ b/src/sdk/cpp/lib/src/logging.cpp
@@ -141,27 +141,20 @@ NamedLogger::NamedLogger(const std::string& name)
     : name_{name} {}
 
 Logger NamedLogger::Debug() const {
-    auto l = logging::Debug();
-    l << name_ << " : ";
-    return l;
+    return logging::Debug() << name_ << " : ";
 }
 
 Logger NamedLogger::Info() const {
-    auto l = logging::Info();
-    l << name_ << " : ";
-    return l;
+    return logging::Info() << name_ << " : ";
 }
 
 Logger NamedLogger::Warn() const {
-    auto l = logging::Warn();
-    l << name_ << " : ";
-    return l;
+    return logging::Warn() << name_ << " : ";
 }
 
 Logger NamedLogger::Error() const {
-    auto l = logging::Error();
-    l << name_ << " : ";
-    return l;
+    return logging::Error() << name_ << " : ";
+
 }
 
 }  // namespace logging

--- a/src/sdk/cpp/lib/src/talent.cpp
+++ b/src/sdk/cpp/lib/src/talent.cpp
@@ -20,7 +20,8 @@ namespace core {
 //
 Talent::Talent(const std::string& talent_id)
     : schema_{schema::Talent{talent_id}}
-    , talent_id_{talent_id} {}
+    , talent_id_{talent_id}
+    , logger_{std::string{"Talent."} + talent_id} {}
 
 void Talent::Initialize(reply_handler_ptr reply_handler, context_generator_func_ptr context_gen, uuid_generator_func_ptr uuid_gen) {
     reply_handler_ = reply_handler;
@@ -79,7 +80,7 @@ schema::Schema Talent::GetSchema() const {
     auto trigger_rules = OnGetRules();
 
     if (!callee_rules && !trigger_rules) {
-        log::Error() << "At least one callee or trigger rule must be defined";
+        GetLogger().Error() << "At least one callee or trigger rule must be defined";
         // TODO better error handling required
         assert(0);
     }
@@ -149,6 +150,10 @@ std::string Talent::GetOutputName(const std::string& talent_id, const std::strin
 
 std::string Talent::GetOutputName(const std::string& type, const std::string& talent_id, const std::string& feature) const {
     return type + "." + GetOutputName(talent_id, feature);
+}
+
+NamedLogger Talent::GetLogger() const {
+    return logger_;
 }
 
 //

--- a/src/sdk/cpp/lib/src/talent_test.cpp
+++ b/src/sdk/cpp/lib/src/talent_test.cpp
@@ -68,7 +68,7 @@ json Test::Json() const {
 //
 // TestSetInfo
 //
-static auto test_set_info_logger = NamedLogger("TestSetInfo");
+static auto logger = NamedLogger("TestSetInfo");
 
 TestSetInfo::TestSetInfo(const std::string& name)
     : name_{name} {}
@@ -79,12 +79,12 @@ void TestSetInfo::AddTest(const std::string& name, const json& exepected_value, 
 }
 
 void TestSetInfo::RunTest(const std::string& name, core::call_ctx_ptr ctx) {
-    test_set_info_logger.Info() << "Run Test " << name;
+    logger.Info() << "Run Test " << name;
 
     auto test = tests_.find(name);
 
     if (test == tests_.end()) {
-        test_set_info_logger.Error() << "Test " << name << " has not been registered";
+        logger.Error() << "Test " << name << " has not been registered";
 
         ctx->Reply(TestResult{name, TEST_ERROR, -1}.Json());
         return;

--- a/src/sdk/cpp/lib/src/talent_test.cpp
+++ b/src/sdk/cpp/lib/src/talent_test.cpp
@@ -16,6 +16,8 @@
 #include "logging.hpp"
 #include "talent_test.hpp"
 
+using iotea::core::logging::NamedLogger;
+
 namespace iotea {
 namespace test {
 
@@ -66,6 +68,8 @@ json Test::Json() const {
 //
 // TestSetInfo
 //
+static auto test_set_info_logger = NamedLogger("TestSetInfo");
+
 TestSetInfo::TestSetInfo(const std::string& name)
     : name_{name} {}
 
@@ -75,12 +79,12 @@ void TestSetInfo::AddTest(const std::string& name, const json& exepected_value, 
 }
 
 void TestSetInfo::RunTest(const std::string& name, core::call_ctx_ptr ctx) {
-    core::log::Info() << "Run Test " << name;
+    test_set_info_logger.Info() << "Run Test " << name;
 
     auto test = tests_.find(name);
 
     if (test == tests_.end()) {
-        core::log::Error() << "Test " << name << " has not been registered";
+        test_set_info_logger.Error() << "Test " << name << " has not been registered";
 
         ctx->Reply(TestResult{name, TEST_ERROR, -1}.Json());
         return;


### PR DESCRIPTION
Added a NamedLogger that adds an aribrary name to the beginning of the
log message.

Made log timestamps UTC and ISO8601 conformant.

Added Talent::GetLogger() method to be used for logging messages that
are associated with Talent functionality.

Signed-off-by: Alexander Perlman <fixed-term.Alexander.Perlman@se.bosch.com>