### PR TITLE
Add rules hash to talent event topic

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "cors": "^2.8.5",
     "debug": "^4.1.1",
     "express": "^4.17.1",
+    "json-stringify-deterministic": "^1.0.1",
     "jsonata": "^1.8.3",
     "mqtt": "^4.2.1",
     "openapi-types": "7.0.1",
     "reconnecting-websocket": "4.4.0",
     "uuid": "^3.4.0",
     "ws": "7.4.6",
+    "xxhashjs": "^0.2.2",
     "yargs": "16.2.0"
   },
   "optionalDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest-cov==2.11.1
 pytest-mock==3.6.0
 pytest-asyncio==0.15.1
 mock==4.0.2
+xxhash==2.0.2

--- a/src/core/configManager.js
+++ b/src/core/configManager.js
@@ -21,6 +21,7 @@ const Talent = require('./talent');
 const PlatformEvents = require('./platformEvents');
 const Logo = require('./logo');
 const ProtocolGateway = require('./protocolGateway');
+const jsonHash = require('./util/jsonHash')
 
 const ErrorMessageFormatter = require('./util/errorMessageFormatter');
 
@@ -197,6 +198,7 @@ module.exports = class ConfigManager {
                 const outputFeatures = Object.keys(outputs).map(feature => (outputs[feature].type || DEFAULT_TYPE) + '.' + feature);
 
                 const rules = RulesLoader.load(discovery.config.rules);
+
                 const typeFeatures = rules.getUniqueTypeFeatures();
 
                 const inputFeatures = [];
@@ -311,8 +313,9 @@ module.exports = class ConfigManager {
 
     async __publishTalentDiscoveryError(discovery, code) {
         try {
+            const rulesHash = jsonHash(discovery.config.rules)
             // Send event straight back to plugin
-            await this.pg.publishJson(Talent.getTalentTopic(discovery.id), {
+            await this.pg.publishJson(Talent.getTalentTopic(discovery.id, rulesHash), {
                 code,
                 msgType: MSG_TYPE_ERROR
             });

--- a/src/core/routing.js
+++ b/src/core/routing.js
@@ -89,12 +89,13 @@ module.exports = class Routing {
                 // Only if true, forward it to the talent --> Maybe make that configurable
                 // Currently a current event can evaluate to false, but the circumventing OrRule evaluates to true
                 // So the whole ruleset evaluates to true
-                this.logger.debug(`Sending event to talent with topic ${Talent.getTalentTopic(id, ev.value.$tsuffix)} to adapter ${config.$adapterId}`, evtctx);
+                const talentTopic = Talent.getTalentTopic(id, config.rulesHash, ev.value.$tsuffix)
+                this.logger.debug(`Sending event to talent with topic ${talentTopic} to adapter ${config.$adapterId}`, evtctx);
 
                 // Just send it to the adapter, the talent is attached to
                 const publishOptions = ProtocolGateway.createPublishOptions(false, config.$adapterId);
 
-                await this.pg.publishJson(Talent.getTalentTopic(id, ev.value.$tsuffix), Object.assign(
+                await this.pg.publishJson(talentTopic, Object.assign(
                     {},
                     ev,
                     {

--- a/src/core/talentConfigManager.js
+++ b/src/core/talentConfigManager.js
@@ -12,6 +12,7 @@ const uuid = require('uuid').v4;
 
 const PlatformEvents = require('./platformEvents');
 const Logger = require('./util/logger');
+const jsonHash = require('./util/jsonHash');
 const ProtocolGateway = require('./protocolGateway');
 
 const {
@@ -99,6 +100,8 @@ module.exports = class TalentConfigManager {
         // Load the given rules
         this.configurations[data.id].rules = RulesLoader.load(this.configurations[data.id].rules);
 
+        this.configurations[data.id].rulesHash = jsonHash(this.configurations[data.id].rules.save(true))
+        
         if (data.source === this.uid) {
             await this.__fireSetConfigFor(data.id, this.configurations[data.id]);
         }

--- a/src/core/util/jsonHash.js
+++ b/src/core/util/jsonHash.js
@@ -1,0 +1,22 @@
+const xxHash = require('xxhashjs')
+const stringify = require('json-stringify-deterministic')
+
+/**
+ * Module JSON Hash.
+ * 
+ * @module jsonHash
+ */
+
+/**
+ * The json object is stringified by sorting the keys, removing spaces and new lines. It is then passed to a function to
+ * calculate the hash code.
+ * 
+ * @param {*} jsonObject - A json object.
+ * @returns a string representing 64-bit hash
+ */
+module.exports = function jsonHash(jsonObject) {
+    const canonicalJsonObject = stringify(jsonObject)
+    return xxHash.h64(canonicalJsonObject, 0).toString(16)
+}
+
+

--- a/src/core/util/jsonQuery.js
+++ b/src/core/util/jsonQuery.js
@@ -186,7 +186,7 @@ function __parseInt(value, defaultValue, radix = 10) {
 
     if (isNaN(p)) {
         if (defaultValue === undefined || !Number.isFinite(defaultValue)) {
-            throw new Error(`Neither parsed valuevalue ${value} nor default value are numbers`);
+            throw new Error(`Neither parsed value ${value} nor default value are numbers`);
         }
 
         return defaultValue;

--- a/src/module.js
+++ b/src/module.js
@@ -96,6 +96,7 @@ const {
 
 const JsonModel = require('./core/util/jsonModel');
 const jsonQuery = require('./core/util/jsonQuery');
+const jsonHash = require('./core/util/jsonHash');
 
 const {
     KuksaValAdapter,
@@ -133,7 +134,8 @@ module.exports = {
         MqttProtocolAdapter,
         Logger,
         JsonModel,
-        jsonQuery
+        jsonQuery,
+        jsonHash
     },
     constants: {
         ALL_INSTANCE_IDS_FILTER,

--- a/src/sdk/python/src/iotea/core/util/json_hash.py
+++ b/src/sdk/python/src/iotea/core/util/json_hash.py
@@ -1,0 +1,25 @@
+##############################################################################
+# Copyright (c) 2021 Bosch.IO GmbH
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+#
+# SPDX-License-Identifier: MPL-2.0
+##############################################################################
+
+import json
+
+import xxhash
+
+def json_hash(json_object):
+    '''
+    Calculates the hash of the stringified version of a json object. The json object is converted into string by sorting
+    the keys, removing spaces and new lines.The hash function converts the json string into utf-8 encoding and generates
+    a 64-bit code.
+    :param json_object: A json object.
+    :return: hex string representation of a 64-bit hash.
+    '''
+    json_str = json.dumps(json_object, indent=None, separators=(',', ':'), ensure_ascii=False, sort_keys=True)
+    # the underlying implementation converts json_str to utf-8 byte[]
+    return xxhash.xxh64(json_str).hexdigest()

--- a/src/sdk/python/src/setup.py
+++ b/src/sdk/python/src/setup.py
@@ -26,7 +26,8 @@ setup(
         "iotea.core.util"
     ],
     install_requires=[
-        "amqtt>=0.10.0a3"
+        "amqtt>=0.10.0a3",
+        "xxhash==2.0.2"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -709,6 +709,11 @@ csv@~0.3.6:
   resolved "https://registry.yarnpkg.com/csv/-/csv-0.3.7.tgz#a4f8a363f0072cd155181e6bb49bd58e5497b31c"
   integrity sha1-pPijY/AHLNFVGB5rtJvVjlSXsxw=
 
+cuint@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cuint/-/cuint-0.2.2.tgz#408086d409550c2631155619e9fa7bcadc3b991b"
+  integrity sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=
+
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1561,6 +1566,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
+json-stringify-deterministic@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stringify-deterministic/-/json-stringify-deterministic-1.0.1.tgz#3334798c374d723d46f7ba0e47d6e5e5ac8511f9"
+  integrity sha512-9Fg0OY3uyzozpvJ8TVbUk09PjzhT7O2Q5kEe30g6OrKhbA/Is92igcx0XDDX7E3yAwnIlUcYLRl+ZkVrBYVP7A==
 
 json5@^2.1.2:
   version "2.2.0"
@@ -2669,11 +2679,6 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.3.1.tgz#d0547bf67f7ce4f12a72dfe31262c68d7dc551c8"
-  integrity sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==
-
 ws@7.4.6, ws@^7.3.1:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
@@ -2709,6 +2714,13 @@ xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
+
+xxhashjs@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/xxhashjs/-/xxhashjs-0.2.2.tgz#8a6251567621a1c46a5ae204da0249c7f8caa9d8"
+  integrity sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==
+  dependencies:
+    cuint "^0.2.2"
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
Signed-off-by: Maria Ivanova <maria.ivanova@bosch.io>

This PR implements the suggestion of https://github.com/GENIVI/iot-event-analytics/issues/112. The PR is created to gather initial reviews.

It covers the issue for JS and Python, and NOT for C++, that's why the integration tests fail. Please, do not merge before all languages are covered.

The PR brings an incompatible change: talents using older versions of sdk will not be able to receive events from iotea carrying this change and vice-versa.