### PR TITLE
Release iotea sdks version 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@
 
 ## [Unreleased]
 
-- 0.5.0, js-sdk-0.5.0, py-sdk-0.5.0
+- 0.6.0, js-sdk-0.6.0, py-sdk-0.6.0 [2021-09-01]
+  - Containerization of the integration tests
+  - Scripts and documentation for Integration Test Framework
+  - Python Test Runner produces JUnit XML Report
+  - TestSetTalent renamed to TestSuiteTalent
+  - Python Unit Tests for the SDK
+
+- 0.5.0, js-sdk-0.5.0, py-sdk-0.5.0 [2021-06-15]
   - js-sdk, py-sdk: Add support for Protocol Gateway feature
 
 - 0.4.1, js-sdk-0.4.1, py-sdk-0.4.1, vscode-sdk-0.9.4 [2021-05-05]

--- a/docker-compose/docker-compose.integration_tests_cpp.yml
+++ b/docker-compose/docker-compose.integration_tests_cpp.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.iotea.version: "0.5.0"
+        iotea.iotea.version: "0.6.0"
       dockerfile: ./docker/integration-tests/cpp-test-suite/test_suite/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}
@@ -18,7 +18,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.iotea.version: "0.5.0"
+        iotea.iotea.version: "0.6.0"
       dockerfile: ./docker/integration-tests/cpp-test-suite/test_fnc/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}

--- a/docker-compose/docker-compose.integration_tests_js.yml
+++ b/docker-compose/docker-compose.integration_tests_js.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.iotea.version: "0.5.0"
+        iotea.iotea.version: "0.6.0"
       dockerfile: ./docker/integration-tests/javascript-test-suite/test_suite/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}
@@ -19,7 +19,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.iotea.version: "0.5.0"
+        iotea.iotea.version: "0.6.0"
       dockerfile: ./docker/integration-tests/javascript-test-suite/test_fnc/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}
@@ -33,7 +33,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.iotea.version: "0.5.0"
+        iotea.iotea.version: "0.6.0"
       dockerfile: ./docker/integration-tests/javascript-test-suite/test_events/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}

--- a/docker-compose/docker-compose.integration_tests_py.yml
+++ b/docker-compose/docker-compose.integration_tests_py.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.iotea.version: "0.5.0"
+        iotea.iotea.version: "0.6.0"
       dockerfile: docker/integration-tests/python-test-suite/test_suite/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}
@@ -19,7 +19,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.iotea.version: "0.5.0"
+        iotea.iotea.version: "0.6.0"
       dockerfile: docker/integration-tests/python-test-suite/test_fnc/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}

--- a/docker-compose/docker-compose.integration_tests_runner.yml
+++ b/docker-compose/docker-compose.integration_tests_runner.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.iotea.version: "0.5.0"
+        iotea.iotea.version: "0.6.0"
       dockerfile: ./docker/integration-tests/python-test-suite/test_runner/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}

--- a/docker-compose/docker-compose.platform-slim.yml
+++ b/docker-compose/docker-compose.platform-slim.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.platform.version: "0.5.0"
+        iotea.platform.version: "0.6.0"
       dockerfile: docker/platform/Dockerfile.slim.amd64
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}

--- a/docker-compose/docker-compose.platform.yml
+++ b/docker-compose/docker-compose.platform.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.platform.version: "0.5.0"
+        iotea.platform.version: "0.6.0"
       dockerfile: docker/config/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}
@@ -23,7 +23,7 @@ services:
     build:
       context: ..
       labels:
-        iotea.platform.version: "0.5.0"
+        iotea.platform.version: "0.6.0"
       dockerfile: docker/pipeline/Dockerfile.${ARCH}
       args:
         - HTTP_PROXY=${DOCKER_HTTP_PROXY}

--- a/get-sdks.js
+++ b/get-sdks.js
@@ -17,8 +17,8 @@ var HttpsProxyAgent = require('https-proxy-agent');
 (async () => {
     await Promise.all([
         download('https://github.com/GENIVI/iot-event-analytics/releases/download/vscode-ext-0.9.8/iotea-0.9.8.vsix', path.resolve(__dirname, 'src', 'sdk', 'vscode', 'lib')),
-        download('https://github.com/GENIVI/iot-event-analytics/releases/download/py-sdk-0.5.0/boschio_iotea-0.5.0-py3-none-any.whl', path.resolve(__dirname, 'src', 'sdk', 'python', 'lib')),
-        download('https://github.com/GENIVI/iot-event-analytics/releases/download/js-sdk-0.5.0/boschio.iotea-0.5.0.tgz', path.resolve(__dirname, 'src', 'sdk', 'javascript', 'lib'))
+        download('https://github.com/GENIVI/iot-event-analytics/releases/download/py-sdk-0.6.0/boschio_iotea-0.6.0-py3-none-any.whl', path.resolve(__dirname, 'src', 'sdk', 'python', 'lib')),
+        download('https://github.com/GENIVI/iot-event-analytics/releases/download/js-sdk-0.6.0/boschio.iotea-0.6.0.tgz', path.resolve(__dirname, 'src', 'sdk', 'javascript', 'lib'))
     ])
         .catch(err => {
             console.error(`ERROR: ${err.message}`);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boschio.iotea",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "jsonApiVersion": "2.0.0",
   "author": "Bosch.IO GmbH",
   "main": "src/module.js",

--- a/src/sdk/python/src/setup.py
+++ b/src/sdk/python/src/setup.py
@@ -15,7 +15,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name="boschio-iotea",
-    version="0.5.0",
+    version="0.6.0",
     author="Bosch.IO GmbH",
     description="Core library for Talent development",
     long_description=LONG_DESCRIPTION,


### PR DESCRIPTION
From CHANGELOG:
0.6.0
- Containerization of the integration tests
- Scripts and documentation for Integration Test Framework
- Python Test Runner produces JUnit XML Report
- Test Set renamed to Test Suite
- Python Unit Tests for the SDK

Signed-off-by: Maria Ivanova <maria.ivanova@bosch.io>