### PR TITLE
Strip off version from VSCode extension file name: iotea-<version>.vsix becomes iotea.vsix

### DIFF
--- a/get-sdks.js
+++ b/get-sdks.js
@@ -16,7 +16,7 @@ var HttpsProxyAgent = require('https-proxy-agent');
 
 (async () => {
     await Promise.all([
-        download('https://github.com/GENIVI/iot-event-analytics/releases/download/vscode-ext-0.9.8/iotea-0.9.8.vsix', path.resolve(__dirname, 'src', 'sdk', 'vscode', 'lib')),
+        download('https://github.com/GENIVI/iot-event-analytics/releases/download/vscode-ext-0.9.9/iotea-0.9.9.vsix', path.resolve(__dirname, 'src', 'sdk', 'vscode', 'lib')),
         download('https://github.com/GENIVI/iot-event-analytics/releases/download/py-sdk-0.6.0/boschio_iotea-0.6.0-py3-none-any.whl', path.resolve(__dirname, 'src', 'sdk', 'python', 'lib')),
         download('https://github.com/GENIVI/iot-event-analytics/releases/download/js-sdk-0.6.0/boschio.iotea-0.6.0.tgz', path.resolve(__dirname, 'src', 'sdk', 'javascript', 'lib'))
     ])

--- a/src/sdk/vscode/CHANGELOG.md
+++ b/src/sdk/vscode/CHANGELOG.md
@@ -12,8 +12,12 @@
 
 ## [Unreleased]
 
+- 0.9.9 [2021-09-13]
+  - pip module name changed from "pip3" to "pip" in vscode settings.
+  - VSCode extension artefact is now generated under two names: iotea-\<version\>.vsix and iotea.vsix. iotea-\<version\>.vsix will be deprecated, use iotea.vsix.
+
 - 0.9.8 [2021-06-30]
-  - Stop MQTT Publisher spawning Node.js processes indefinitly
+  - Stop MQTT Publisher spawning Node.js processes indefinitely
 
 - 0.9.7 [2021-06-17]
   - Fix breaking change in vss-tools API for creating a vss file
@@ -21,7 +25,7 @@
 - 0.9.6 [2021-06-17]
   - Fix version parsing of unknown docker-compose builds
   - Add troubleshooting entry for making hidden files visible in the file open dialog for macOS
-  - Add button captions of file dialogs to compensate for hidden dialog titel on macOS
+  - Add button captions of file dialogs to compensate for hidden dialog title on macOS
 
 - 0.9.5 [2021-06-07]
   - Update certificate path within Kuksa.VAL repository

--- a/src/sdk/vscode/README.md
+++ b/src/sdk/vscode/README.md
@@ -26,7 +26,7 @@ Additionally, all requirements will be checked on the first command invocation a
 ## Installation
 
 - Go to _View_ > _Extensions_ > _..._ > _Install from VSIX_
-- Select the desired version from _lib/iotea-\<version\>.vsix_
+- Select _lib/iotea.vsix_
 - Restart Visual Studio Code
 
 ## Settings

--- a/src/sdk/vscode/package.json
+++ b/src/sdk/vscode/package.json
@@ -5,7 +5,7 @@
     "categories": [
         "Snippets"
     ],
-    "version": "0.9.8",
+    "version": "0.9.9",
     "license": "MPL-2.0",
     "private": "true",
     "author": "Bosch.IO GmbH",
@@ -193,7 +193,7 @@
     },
     "scripts": {
         "vscode:prepublish": "yarn compile:prod",
-        "package": "mkdirp ./lib&&vsce package --yarn --out lib/",
+        "package": "mkdirp ./lib && vsce package --yarn --out lib/ && vsce package --yarn --out lib/iotea.vsix",
         "precompile:prod": "yarn precompile",
         "precompile:dev": "yarn precompile",
         "precompile": "del-cli out/&&cpy resources/**/* out/ --parents",


### PR DESCRIPTION

Signed-off-by: Maria Ivanova <maria.ivanova@bosch.io>