### PR TITLE
Feature/remove vscode vssfunctions

### DIFF
--- a/src/sdk/vscode/CHANGELOG.md
+++ b/src/sdk/vscode/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ## [Unreleased]
 
+- 0.9.91 [2021-10-06]
+  - removed VSCode functions to build types.json from vss.json 
+  
 - 0.9.9 [2021-09-13]
   - pip module name changed from "pip3" to "pip" in vscode settings.
   - VSCode extension artefact is now generated under two names: iotea-\<version\>.vsix and iotea.vsix. iotea-\<version\>.vsix will be deprecated, use iotea.vsix.

--- a/src/sdk/vscode/CHANGELOG.md
+++ b/src/sdk/vscode/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## [Unreleased]
 
-- 0.9.91 [2021-10-06]
+- 0.9.10 [2021-10-06]
   - removed VSCode functions to build types.json from vss.json 
   
 - 0.9.9 [2021-09-13]

--- a/src/sdk/vscode/package.json
+++ b/src/sdk/vscode/package.json
@@ -49,16 +49,6 @@
                 "command": "iotea.publishMqttMessage",
                 "title": "Publish an MQTT message",
                 "category": "Bosch IoT Event Analytics"
-            },
-            {
-                "command": "iotea.vss.createIoTeaTypesFromVssJson",
-                "title": "Convert VSS configuration to IoT Event Analytics types configuration",
-                "category": "Vehicle Signal Specification"
-            },
-            {
-                "command": "iotea.vss.createKuksaValConfiguration",
-                "title": "Create configuration for Kuksa.VAL (including VSS configuration)",
-                "category": "Vehicle Signal Specification"
             }
         ],
         "snippets": [

--- a/src/sdk/vscode/package.json
+++ b/src/sdk/vscode/package.json
@@ -5,7 +5,7 @@
     "categories": [
         "Snippets"
     ],
-    "version": "0.9.91",
+    "version": "0.9.10",
     "license": "MPL-2.0",
     "private": "true",
     "author": "Bosch.IO GmbH",

--- a/src/sdk/vscode/package.json
+++ b/src/sdk/vscode/package.json
@@ -5,7 +5,7 @@
     "categories": [
         "Snippets"
     ],
-    "version": "0.9.9",
+    "version": "0.9.91",
     "license": "MPL-2.0",
     "private": "true",
     "author": "Bosch.IO GmbH",


### PR DESCRIPTION
removed the inline function to convert vss.json to types.json.
the converted types.json (per VSS release) are part of the release in src/tools/vss.